### PR TITLE
remove restore_cache for regenerating cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - npm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Setup
-          command: npm ci
+          command: npm install --unsafe-perm
       - save_cache:
           key: npm-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - npm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Setup
-          command: npm install
+          command: npm ci
       - save_cache:
           key: npm-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "main": "Gruntfile.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TechBooster/ReVIEW-Template.git"
+    "url": "git+https://github.com/greebookfestclub/bookfest7.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/TechBooster/ReVIEW-Template/issues"
+    "url": "https://github.com/greebookfestclub/bookfest7/issues"
   },
-  "homepage": "https://github.com/TechBooster/ReVIEW-Template#readme",
+  "homepage": "https://github.com/greebookfestclub/bookfest7/blob/master/README.md",
   "engines": {
     "node": ">=6.0.0"
   },

--- a/test-in-docker.sh
+++ b/test-in-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+[ ! -z $REVIEW_CONFIG_FILE ] || REVIEW_CONFIG_FILE=config.yml
+
+# コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
+# docker run -i -t -v $(pwd):/book vvakame/review:3.1 /bin/bash
+
+docker run -t --rm -v $(pwd):/book vvakame/review:3.1 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run test"


### PR DESCRIPTION
手元では成功するが、CircleCIでは失敗する。
原因はnpm installが失敗していたこと。
取り急ぎ、unsafe-paramを付けることで成功した。
失敗している方もこのPRの変更を取り込めばできるようになります。

repos名とか修正している所は気づいたのでついでに直しているだけで、失敗には無関係です。